### PR TITLE
[WIP] CP-28572 docker compose file to run w/ ecosystem_database_app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m -u 1000 -s /bin/bash bety
 
+# make log writable
+RUN chown -R bety:bety /home/bety/log/
+RUN chmod -R 755 /home/bety/log/
+
 # change to working directory
 USER bety
 WORKDIR /home/bety

--- a/docker-compose.indigo-onedb.yml
+++ b/docker-compose.indigo-onedb.yml
@@ -16,10 +16,9 @@ services:
       - PGUSER=bety
       - PGOPTIONS=-c search_path=ecosystem_observation_app # This sets the schema to use for PostgreSQL queries
       - PGDATABASE=postgres
-      - PGHOST=localhost # OneDB
-      - PGPORT=19849     # OneDB Ecosystem Observation App - Yggdrasil - Development
-      - PGHOST=host.docker.internal # Docker
-      - PGHOST=5432                 # Docker
+      - PGHOST=host.docker.internal
+      - PGPORT=19840     # OneDB Ecosystem Observation App - Yggdrasil - Development
+#     - PGHOST=5432                 # Docker
     restart: unless-stopped
 
 networks:

--- a/docker-compose.indigo-onedb.yml
+++ b/docker-compose.indigo-onedb.yml
@@ -16,8 +16,10 @@ services:
       - PGUSER=bety
       - PGOPTIONS=-c search_path=ecosystem_observation_app # This sets the schema to use for PostgreSQL queries
       - PGDATABASE=postgres
-      - PGHOST=host.docker.internal
-      - PGPORT=5432 # 19840         # Ecosystem Observation App - Yggdrasil - Development
+      - PGHOST=localhost # OneDB
+      - PGPORT=19849     # OneDB Ecosystem Observation App - Yggdrasil - Development
+      - PGHOST=host.docker.internal # Docker
+      - PGHOST=5432                 # Docker
     restart: unless-stopped
 
 networks:

--- a/docker-compose.indigo.yml
+++ b/docker-compose.indigo.yml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+  # BETY rails frontend to the database
+  bety_local:
+    # build: . # to build after updating Dockerfile
+    image: bety_local-bety_local:latest # or pecan/bety:latest to pull from dockerhub (?)
+    networks:
+      - bety_local
+    ports:
+      - 8000
+    environment:
+      - UNICORN_WORKER_PROCESSES=1
+      - SECRET_KEY_BASE=thisisnotasecret
+      - PGUSER=bety
+      - PGOPTIONS=-c search_path=ecosystem_observation_app # This sets the schema to use for PostgreSQL queries
+      - PGDATABASE=postgres
+      - PGHOST=host.docker.internal
+      - PGPORT=19840         # Ecosystem Observation App - Yggdrasil - Development
+    restart: unless-stopped
+
+networks:
+  bety_local:
+  


### PR DESCRIPTION
* added PG* environment variables to change default schema and port
* maybe this file should go in https://github.com/indigo-ag/ecosystem-observation-database ???

I think to test it out:

```
## start the database
docker-compose -p bety up -d postgres

## start the web app w/ docker db (currently works)
docker-compose -f docker-compose.indigo.yml -p bety up

## start web app w/ onedb (currently fails, just keeps restarting)
docker-compose -f docker-compose.indigo-onedb.yml -p bety up
```

here is some data that should populate the database:

[demo_inserts.sql.zip](https://github.com/indigo-ag/bety/files/11501118/demo_inserts.sql.zip)
